### PR TITLE
Example works with plain cloudformation instead of cfndsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'cfndsl'
+group :tools do
+  gem 'cfndsl'
+  gem 'pry', '~> 0.10'
+  gem 'rb-readline'
+end

--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ Or install it yourself as:
 
 Take a look at the examples Inspec profile at `examples/profile`. You can run `examples/bin/demo_noncompliant_vpc.rb` which will launch a CloudFormation stack in us-west-2, run the inspec profile against it, and then delete the stack. The script assumes you have AWS cli credentials already setup.
 
+A full run of the example with a local Bundle install will look like this, with Inspec 0.26.0:
+
+```
+env | grep -q AWS_SECRET && env | grep -q AWS_ACCESS || echo "Set AWS credentials"
+bundle install --path vendor/bundle
+bundle exec examples/bin/demo_noncompliant_vpc.rb
+```
+
+Results:
+```
+Launching CFN stack InspecAwsDemo-NonCompliant-20160629165421 in us-west-2
+Waiting for stack to come up...
+Stack created - vpc-id[vpc-a5b6c6c1]
+Running Inspec on example profile...
+  ✔  sg-1: Security Group sg-beee79d8 should not have ingress rule
+
+
+Profile: Example profile (Example profile)
+Version: 1.0.0
+Target:  local://
+
+     No tests executed.
+
+Summary:   1 successful    1 failures    0 skipped
+Deleting stack InspecAwsDemo-NonCompliant-20160629165421
+```
+
+The 'successful' test is on the default SecurityGroup, the failure is not, as of this writing, reported clearly. For more detail, uncomment the line with `print JSON.pretty_generate(runner.report)`
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/arothian/inspec-aws.

--- a/examples/noncompliant_vpc.json
+++ b/examples/noncompliant_vpc.json
@@ -1,0 +1,45 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Inspec-aws demo",
+  "Resources": {
+    "vpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true,
+        "CidrBlock": "10.1.0.0/16",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Inspec DEMO VPC"
+          }
+        ]
+      }
+    },
+    "AllowSSHFromEveryoneSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "vpc"
+        },
+        "GroupDescription": "Enable SSH access and HTTP access on the inbound port",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "vpcid": {
+      "Description": "The VPC id",
+      "Value": {
+        "Ref": "vpc"
+      }
+    }
+  }
+}

--- a/examples/profile/controls/test.rb
+++ b/examples/profile/controls/test.rb
@@ -3,9 +3,9 @@ control 'sg-1' do
   impact 1.0
   title 'Security Group: No ingress access to CIDR block 0.0.0.0/0'
   desc 'Security Groups must not allow inbound access from anywhere'
-  
+
   Vpc.new(id: ENV['vpc_id']).security_groups.each do |security_group|
-    describe security_group do
+    describe SecurityGroup.new(id:security_group.id) do
       it { should_not have_ingress_rule().with_source('0.0.0.0/0') }
     end
   end

--- a/inspec-aws.gemspec
+++ b/inspec-aws.gemspec
@@ -9,17 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Kevin Formsma"]
   spec.email         = ["kevin.formsma@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
-
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
+  spec.summary       = %q{Extend Inspec with tests against the AWS platform}
+  spec.homepage      = "https://github.com/arothian/inspec-aws"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
I've updated the examples to work with current versions in inspec and this project.

`cfndsl` was producing bogus json. with AWS::APIGateway resources instead of SecurityGroups, so I've gone to straight up CF json.

Update the profile and example to work, as show.

HTH, Peter
